### PR TITLE
Typos fixed, and blank lines added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](/assets/luos-logo.png)
 
 # Luos Documentation
-Luos is a set of hardware and software librairies, written in Rust, that orchestrates your robotic system. See https://www.luos.io/ for more.
+Luos is a set of hardware and software libraries, written in Rust, that orchestrates your robotic system. See https://www.luos.io/ for more.
 
 Luos is Open Source (Apache 2.0), you can star, clone and fork it on Github: https://github.com/pollen-robotics/luos
 
@@ -10,12 +10,18 @@ Do not hesitate to join the [community](https://www.luos.io/#pricing) and obtain
 ## Get Started
 
 1. [Installation guide](/installation_guide/README.md): setup for Rust for embedded on you computer
+
 2. [Available development boards](/tutorials/00_development_boards.md): select the board that is right for you
-3. [Hello world: compile and upload your first program](/tutorials/01_your_first_program.md): learn to toggle an led on an off at the press of a button
-4. [Taking a short break or how to pause your program for a bit](/tutorials/02_blink_an_led.md): learn to blink a led at a defined frequency5
+
+3. [Hello world: compile and upload your first program](/tutorials/01_your_first_program.md): learn to toggle a led on an off at the press of a button
+
+4. [Taking a short break, or how to pause your program for a bit](/tutorials/02_blink_an_led.md): learn to blink a led at a defined frequency
+
 5. [Taking a deep breath, using PWM to change led brightness](/tutorials/03_led_brightness_with_pwm.md): learn to use PWM to create a breathing behavior on your led
-6. [Reading analog values](/tutorials/04_led_brightness_via_potentiometer.md): learn to read an analog value from a pin, control a led brightness using a potentiometer
-7. [Build a remote controlled elastic gun](/tutorials/05_servo_control_via_potentiometer.md): learn to control a servomotor, create a remote controlled elastic gun and use it to rule the world
+
+6. [Reading analog values](/tutorials/04_led_brightness_via_potentiometer.md): learn to read an analog value from a pin, and control led brightness using a potentiometer
+
+7. [Build a remote controlled elastic gun](/tutorials/05_servo_control_via_potentiometer.md): learn to control a servomotor, and create a remotely controlled elastic gun to rule the world
 
 ## About
 Luos is developed by [Pollen Robotics](https://www.pollen-robotics.com/).


### PR DESCRIPTION
Note that I'm not a native English speaker, so I might just as well have it wrong!

The added blank lines hopefully result in small comment boxes appearing for logged-in users:
I noticed that some list items have them popping up next to them, and some don't. I suspect it's because of a preceding blank line.